### PR TITLE
Implement/cheerio parsing

### DIFF
--- a/TempInfo.txt
+++ b/TempInfo.txt
@@ -1,2 +1,0 @@
-  "dev": "concurrently -k -p \"[{name}]\" -n \"TypeScript,App\" -c \"yellow.bold,cyan.bold\" \"tsc -w\" \"nodemon\"",
-   "dev": "tsc -w",

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,13 +19,14 @@
         "@prisma/client": "^6.16.2",
         "bcrypt": "^6.0.0",
         "bcryptjs": "^3.0.2",
+        "cheerio": "^1.1.2",
         "fastify": "^5.6.0",
         "fastify-plugin": "^5.0.1",
         "json-schema-to-ts": "^3.1.1",
         "rss-parser": "^3.13.0"
       },
       "devDependencies": {
-        "@biomejs/biome": "^2.2.4",
+        "@biomejs/biome": "2.2.4",
         "@fastify/type-provider-json-schema-to-ts": "^5.0.0",
         "@types/bcrypt": "^6.0.0",
         "@types/bcryptjs": "^2.4.6",
@@ -804,6 +805,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+      "license": "ISC"
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
@@ -915,6 +922,48 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/cheerio": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.1.2.tgz",
+      "integrity": "sha512-IkxPpb5rS/d1IiLbHMgfPuS0FgiWTtFIm/Nj+2woXDLTZ7fOT2eqzgYbdMlLweqlHbsZjxEChoVK+7iph7jyQg==",
+      "license": "MIT",
+      "dependencies": {
+        "cheerio-select": "^2.1.0",
+        "dom-serializer": "^2.0.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "encoding-sniffer": "^0.2.1",
+        "htmlparser2": "^10.0.0",
+        "parse5": "^7.3.0",
+        "parse5-htmlparser2-tree-adapter": "^7.1.0",
+        "parse5-parser-stream": "^7.1.2",
+        "undici": "^7.12.0",
+        "whatwg-mimetype": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=20.18.1"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/cheerio?sponsor=1"
+      }
+    },
+    "node_modules/cheerio-select": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-2.1.0.tgz",
+      "integrity": "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-select": "^5.1.0",
+        "css-what": "^6.1.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
       }
     },
     "node_modules/chokidar": {
@@ -1052,6 +1101,34 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/css-select": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+      "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-what": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
+      "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -1122,6 +1199,73 @@
         "node": ">=0.3.1"
       }
     },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/dom-serializer/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
     "node_modules/dotenv": {
       "version": "16.6.1",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
@@ -1169,6 +1313,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/encoding-sniffer": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/encoding-sniffer/-/encoding-sniffer-0.2.1.tgz",
+      "integrity": "sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "^0.6.3",
+        "whatwg-encoding": "^3.1.1"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/encoding-sniffer?sponsor=1"
       }
     },
     "node_modules/entities": {
@@ -1470,6 +1627,37 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/htmlparser2": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.0.0.tgz",
+      "integrity": "sha512-TwAZM+zE5Tq3lrEHvOlvwgj1XLWQCtaaibSN11Q+gGBAS7Y1uZSWwXXRe4iF6OXnaq1riyQAPFOBtYc77Mxq0g==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.1",
+        "entities": "^6.0.0"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/http-errors": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
@@ -1484,6 +1672,18 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/ignore-by-default": {
@@ -1818,6 +2018,18 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/nth-check": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
+      }
+    },
     "node_modules/nypm": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/nypm/-/nypm-0.6.2.tgz",
@@ -1852,6 +2064,55 @@
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-htmlparser2-tree-adapter": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.1.0.tgz",
+      "integrity": "sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==",
+      "license": "MIT",
+      "dependencies": {
+        "domhandler": "^5.0.3",
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-parser-stream": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/parse5-parser-stream/-/parse5-parser-stream-7.1.2.tgz",
+      "integrity": "sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow==",
+      "license": "MIT",
+      "dependencies": {
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/pathe": {
@@ -2126,6 +2387,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
     },
     "node_modules/sax": {
       "version": "1.4.1",
@@ -2453,6 +2720,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/undici": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.16.0.tgz",
+      "integrity": "sha512-QEg3HPMll0o3t2ourKwOeUAZ159Kn9mx5pnzHRQO8+Wixmh88YdZRiIwat0iNzNNXn0yoEtXJqFpyW7eM8BV7g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
     "node_modules/undici-types": {
       "version": "7.12.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.12.0.tgz",
@@ -2474,6 +2750,27 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/wrap-ansi": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "seed": "prisma db seed"
   },
   "prisma": {
-    "seed": "ts-node prisma/seed.ts"
+    "seed:users": "ts-node prisma/seed/seed.users.ts",
+    "seed:feeds": "ts-node prisma/seeds/seed.feeds.ts"
   },
   "author": "",
   "license": "ISC",
@@ -32,6 +33,7 @@
     "@prisma/client": "^6.16.2",
     "bcrypt": "^6.0.0",
     "bcryptjs": "^3.0.2",
+    "cheerio": "^1.1.2",
     "fastify": "^5.6.0",
     "fastify-plugin": "^5.0.1",
     "json-schema-to-ts": "^3.1.1",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -24,6 +24,34 @@ model Feed {
   @@map("feeds")
 }
 
+
+
+// model Feed {
+//   id           String   @id @default(auto()) @map("_id") @db.ObjectId
+//
+//   sourceUrl    String   @unique                   // URL RSS/Atom
+//   sourceDomain String                             // Домен сайту
+//   title        String                             // Назва фіда
+//   description  String?                            // Короткий опис
+//   link         String?                            // Посилання на сайт (homepage)
+//   language     String?                            // Напр. "en", "uk"
+//   category     String                             // Категорія (world, tech, ua...)
+//   imageUrl     String?                            // Логотип/іконка
+//   isActive     Boolean  @default(true)            // Виключати без видалення
+//   items        Json                               // Оригінальний items[] (як зараз)
+//   allowHttp Boolean @default(false)               // Чи захищений
+//
+//
+//   createdAt    DateTime @default(now())
+//   updatedAt    DateTime @updatedAt
+//
+//   @@map("feeds")
+//   @@index([category])
+//   @@index([sourceDomain])
+//   @@index([isActive, category])
+// }
+
+
 model User {
   id           String   @id @default(auto()) @map("_id") @db.ObjectId
   email        String   @unique

--- a/prisma/seeds/seed.feeds.ts
+++ b/prisma/seeds/seed.feeds.ts
@@ -8,6 +8,7 @@ type SeedFeed = {
     category: 'world' | 'tech' | 'ua' | 'sports';
 };
 
+// World news feeds
 const WORLD: SeedFeed[] = [
     { title: 'BBC News', sourceUrl: 'https://feeds.bbci.co.uk/news/rss.xml', category: 'world' },
     { title: 'CNN World', sourceUrl: 'https://rss.cnn.com/rss/edition_world.rss', category: 'world' },
@@ -16,6 +17,7 @@ const WORLD: SeedFeed[] = [
     { title: 'New York Times Home', sourceUrl: 'https://rss.nytimes.com/services/xml/rss/nyt/HomePage.xml', category: 'world' },
 ];
 
+// Technology news feeds
 const TECH: SeedFeed[] = [
     { title: 'Hacker News', sourceUrl: 'https://news.ycombinator.com/rss', category: 'tech' },
     { title: 'TechCrunch', sourceUrl: 'https://techcrunch.com/feed/', category: 'tech' },
@@ -32,50 +34,55 @@ const UA: SeedFeed[] = [
     { title: 'ТСН', sourceUrl: 'https://tsn.ua/rss/full.rss', category: 'ua' },
 ];
 
+// Sports news feeds
 const SPORTS: SeedFeed[] = [
     { title: 'BBC Sport', sourceUrl: 'http://feeds.bbci.co.uk/sport/rss.xml?edition=uk', category: 'sports' },
     { title: 'ESPN Top Headlines', sourceUrl: 'https://www.espn.com/espn/rss/news', category: 'sports' },
     { title: 'Sky Sports Top Stories', sourceUrl: 'https://www.skysports.com/rss/12040', category: 'sports' },
 ];
 
-function getSourceDomain(u: string): string {
+// Extract domain name from URL
+function getSourceDomain(url: string): string {
     try {
-        return new URL(u).host.replace(/^www\./, '');
+        return new URL(url).host.replace(/^www\./, '');
     } catch {
         return '';
     }
 }
 
 async function main() {
-    //Clearing the collection
+    // Clear existing feeds from database
     await prisma.feed.deleteMany({});
 
-    const all: SeedFeed[] = [...WORLD, ...TECH, ...UA, ...SPORTS];
+    // Combine all feed categories into one array
+    const allFeeds: SeedFeed[] = [...WORLD, ...TECH, ...UA, ...SPORTS];
 
-    // Filling out the Prisma model
-    const rows = all.map((f) => ({
-        title: f.title,
-        sourceUrl: f.sourceUrl,
-        sourceDomain: getSourceDomain(f.sourceUrl),
-        category: f.category,
+    // Prepare data for Prisma model
+    const feedRows = allFeeds.map((feed) => ({
+        title: feed.title,
+        sourceUrl: feed.sourceUrl,
+        sourceDomain: getSourceDomain(feed.sourceUrl),
+        category: feed.category,
         description: null as string | null,
         link: null as string | null,
         language: null as string | null,
         imageUrl: null as string | null,
         isActive: true,
-        items: [] ,         // за моделлю items: Json — кладемо порожній масив
+        items: [], // Empty array for Json field according to model
     }));
 
+    // Insert all feeds into database
     await prisma.feed.createMany({
-        data: rows,
+        data: feedRows,
     });
 
-    console.log(`Seeded feeds: ${rows.length}`);
+    console.log(`Successfully seeded ${feedRows.length} feeds`);
 }
 
+// Run the seeding process
 main()
-    .catch((e) => {
-        console.error(e);
+    .catch((error) => {
+        console.error('Seeding failed:', error);
         process.exit(1);
     })
     .finally(async () => {

--- a/prisma/seeds/seed.feeds.ts
+++ b/prisma/seeds/seed.feeds.ts
@@ -1,0 +1,83 @@
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+type SeedFeed = {
+    title: string;
+    sourceUrl: string;
+    category: 'world' | 'tech' | 'ua' | 'sports';
+};
+
+const WORLD: SeedFeed[] = [
+    { title: 'BBC News', sourceUrl: 'https://feeds.bbci.co.uk/news/rss.xml', category: 'world' },
+    { title: 'CNN World', sourceUrl: 'https://rss.cnn.com/rss/edition_world.rss', category: 'world' },
+    { title: 'Reuters Top News', sourceUrl: 'https://feeds.reuters.com/reuters/topNews', category: 'world' },
+    { title: 'The Guardian World', sourceUrl: 'https://www.theguardian.com/world/rss', category: 'world' },
+    { title: 'New York Times Home', sourceUrl: 'https://rss.nytimes.com/services/xml/rss/nyt/HomePage.xml', category: 'world' },
+];
+
+const TECH: SeedFeed[] = [
+    { title: 'Hacker News', sourceUrl: 'https://news.ycombinator.com/rss', category: 'tech' },
+    { title: 'TechCrunch', sourceUrl: 'https://techcrunch.com/feed/', category: 'tech' },
+    { title: 'Smashing Magazine', sourceUrl: 'https://www.smashingmagazine.com/feed/', category: 'tech' },
+    { title: 'Ars Technical', sourceUrl: 'http://feeds.arstechnica.com/arstechnica/index', category: 'tech' },
+    { title: 'Dev.to (Home)', sourceUrl: 'https://dev.to/feed/', category: 'tech' },
+];
+
+const UA: SeedFeed[] = [
+    { title: 'Укрінформ (Останні новини)', sourceUrl: 'https://www.ukrinform.ua/rss/block-lastnews', category: 'ua' },
+    { title: 'ЛІГА.net (усі новини)', sourceUrl: 'https://www.liga.net/news/all/rss.xml', category: 'ua' },
+    { title: 'Економічна правда', sourceUrl: 'https://www.epravda.com.ua/rss/', category: 'ua' },
+    { title: 'НВ (усі новини)', sourceUrl: 'https://nv.ua/rss/all.xml', category: 'ua' },
+    { title: 'ТСН', sourceUrl: 'https://tsn.ua/rss/full.rss', category: 'ua' },
+];
+
+const SPORTS: SeedFeed[] = [
+    { title: 'BBC Sport', sourceUrl: 'http://feeds.bbci.co.uk/sport/rss.xml?edition=uk', category: 'sports' },
+    { title: 'ESPN Top Headlines', sourceUrl: 'https://www.espn.com/espn/rss/news', category: 'sports' },
+    { title: 'Sky Sports Top Stories', sourceUrl: 'https://www.skysports.com/rss/12040', category: 'sports' },
+];
+
+function getSourceDomain(u: string): string {
+    try {
+        return new URL(u).host.replace(/^www\./, '');
+    } catch {
+        return '';
+    }
+}
+
+async function main() {
+    //Clearing the collection
+    await prisma.feed.deleteMany({});
+
+    const all: SeedFeed[] = [...WORLD, ...TECH, ...UA, ...SPORTS];
+
+    // Filling out the Prisma model
+    const rows = all.map((f) => ({
+        title: f.title,
+        sourceUrl: f.sourceUrl,
+        sourceDomain: getSourceDomain(f.sourceUrl),
+        category: f.category,
+        description: null as string | null,
+        link: null as string | null,
+        language: null as string | null,
+        imageUrl: null as string | null,
+        isActive: true,
+        items: [] ,         // за моделлю items: Json — кладемо порожній масив
+    }));
+
+    await prisma.feed.createMany({
+        data: rows,
+    });
+
+    console.log(`Seeded feeds: ${rows.length}`);
+}
+
+main()
+    .catch((e) => {
+        console.error(e);
+        process.exit(1);
+    })
+    .finally(async () => {
+        await prisma.$disconnect();
+    });

--- a/prisma/seeds/seed:users.ts
+++ b/prisma/seeds/seed:users.ts
@@ -1,4 +1,4 @@
-// prisma/seed.ts
+// prisma/seed:users.ts
 import { PrismaClient } from '@prisma/client';
 import { hash } from 'bcrypt';
 import { randomBytes } from 'crypto';

--- a/src/app.ts
+++ b/src/app.ts
@@ -2,9 +2,9 @@ import { join } from "node:path";
 import AutoLoad from "@fastify/autoload";
 import Fastify, { type FastifyServerOptions } from "fastify";
 import configPlugin from "./config";
+import { parseRoutes } from "./modules/articalParser/routes/artical.parser.route";
 import { authRoutes } from "./modules/auth/routes/auth.routes";
 import { getFeedDataRoutes } from "./modules/feedParser/routes/feedParser.route";
-import { parseRoutes } from "./modules/articalParser/routes/artical.parser.route"
 
 export type AppOptions = Partial<FastifyServerOptions>;
 
@@ -34,7 +34,7 @@ async function buildApp(options: AppOptions = {}) {
 
 	fastify.register(getFeedDataRoutes);
 	fastify.register(authRoutes, { prefix: "/api" });
-    fastify.register(parseRoutes, { prefix: "/api" });
+	fastify.register(parseRoutes, { prefix: "/api" });
 	return fastify;
 }
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -4,6 +4,7 @@ import Fastify, { type FastifyServerOptions } from "fastify";
 import configPlugin from "./config";
 import { authRoutes } from "./modules/auth/routes/auth.routes";
 import { getFeedDataRoutes } from "./modules/feedParser/routes/feedParser.route";
+import { parseRoutes } from "./modules/articalParser/routes/artical.parser.route"
 
 export type AppOptions = Partial<FastifyServerOptions>;
 
@@ -33,7 +34,7 @@ async function buildApp(options: AppOptions = {}) {
 
 	fastify.register(getFeedDataRoutes);
 	fastify.register(authRoutes, { prefix: "/api" });
-
+    fastify.register(parseRoutes, { prefix: "/api" });
 	return fastify;
 }
 

--- a/src/modules/articalParser/controllers/artical.parse.controller.ts
+++ b/src/modules/articalParser/controllers/artical.parse.controller.ts
@@ -1,28 +1,43 @@
-// modules/articalParser/controllers/artical.parse.controller.ts
+// controllers/artical.parse.controller.ts
+
 import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
 import { parseArticle } from "../services/artical.parse.service";
+function sanitizeAndNormalizeUrl(raw: unknown): string {
+    if (typeof raw !== "string") throw new Error("URL must be a string");
+
+    let s = raw.trim().replace(/[\u200B-\u200D\uFEFF]/g, ""); // zero-width
+    if (s.includes("…")) throw new Error("URL looks truncated (contains …)");
+    // якщо раптом прослизнули пробіли — закодуємо
+    if (/\s/.test(s)) s = s.replace(/\s+/g, "%20");
+
+    let u: URL;
+    try { u = new URL(s); } catch { throw new Error("Invalid URL"); }
+    if (!/^https?:$/.test(u.protocol)) throw new Error("Only http/https URLs are supported.");
+    return u.toString();
+}
 
 export function parseArticleController(fastify: FastifyInstance) {
     return {
         parseArticleController: async (req: FastifyRequest, reply: FastifyReply) => {
-            const url = (req.body as { url?: string } | undefined)?.url;
-            if (!url) return reply.badRequest("Field 'url' is required.");
-
             try {
-                const result = await parseArticle(url);
+                const body = req.body as { url?: string; force?: boolean } | undefined;
+                if (!body?.url) return reply.badRequest("Field 'url' is required.");
+                const url = sanitizeAndNormalizeUrl(body.url);
+
+                const result = await parseArticle(url, body.force === true);
                 return reply.send(result);
             } catch (err: any) {
+                const msg = err?.message || "Unexpected error";
+                if (/URL/.test(msg) || /Invalid URL/.test(msg)) {
+                    return reply.status(400).send({ message: msg });
+                }
                 if (err?.code === "UNSUPPORTED_SITE") {
-                    return reply.status(422).send({ message: "This URL looks like SPA/SSR or dynamic. Static pages only." });
+                    return reply.status(422).send({ message: "Dynamic (SPA/SSR) page detected. Static pages only." });
                 }
-                if (err?.code === "FETCH_FAILED") {
-                    return reply.status(502).send({ message: "Failed to fetch the source URL." });
-                }
-                if (err?.code === "PARSING_FAILED") {
-                    return reply.status(500).send({ message: "Failed to parse the article HTML." });
-                }
+                if (err?.code === "FETCH_FAILED") return reply.status(502).send({ message: "Failed to fetch the source URL." });
+                if (err?.code === "PARSING_FAILED") return reply.status(500).send({ message: "Failed to parse the article HTML." });
                 fastify.log.error({ err }, "parseArticleController failed");
-                return reply.status(500).send({ message: "Unexpected error" });
+                return reply.status(500).send({ message: msg });
             }
         },
     };

--- a/src/modules/articalParser/controllers/artical.parse.controller.ts
+++ b/src/modules/articalParser/controllers/artical.parse.controller.ts
@@ -1,0 +1,29 @@
+// modules/articalParser/controllers/artical.parse.controller.ts
+import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
+import { parseArticle } from "../services/artical.parse.service";
+
+export function parseArticleController(fastify: FastifyInstance) {
+    return {
+        parseArticleController: async (req: FastifyRequest, reply: FastifyReply) => {
+            const url = (req.body as { url?: string } | undefined)?.url;
+            if (!url) return reply.badRequest("Field 'url' is required.");
+
+            try {
+                const result = await parseArticle(url);
+                return reply.send(result);
+            } catch (err: any) {
+                if (err?.code === "UNSUPPORTED_SITE") {
+                    return reply.status(422).send({ message: "This URL looks like SPA/SSR or dynamic. Static pages only." });
+                }
+                if (err?.code === "FETCH_FAILED") {
+                    return reply.status(502).send({ message: "Failed to fetch the source URL." });
+                }
+                if (err?.code === "PARSING_FAILED") {
+                    return reply.status(500).send({ message: "Failed to parse the article HTML." });
+                }
+                fastify.log.error({ err }, "parseArticleController failed");
+                return reply.status(500).send({ message: "Unexpected error" });
+            }
+        },
+    };
+}

--- a/src/modules/articalParser/routes/artical.parser.route.ts
+++ b/src/modules/articalParser/routes/artical.parser.route.ts
@@ -1,0 +1,41 @@
+// modules/parse/artical.parse.route.ts
+import type {JsonSchemaToTsProvider} from "@fastify/type-provider-json-schema-to-ts";
+import {FastifyInstance} from "fastify";
+import {parseArticleController} from "../controllers/artical.parse.controller";
+
+import {
+    parseArticleBody,
+    parseArticleResponse,
+} from "../schema/artical.parser.schema"
+
+
+export async function parseRoutes(fastify: FastifyInstance) {
+    const route = fastify.withTypeProvider<JsonSchemaToTsProvider>();
+    const controller = parseArticleController(fastify);
+
+
+    route.post(
+        "/parse",
+        {schema: {body: parseArticleBody, response: {200: parseArticleResponse}}},
+        controller.parseArticleController,
+    );
+
+
+
+}
+
+
+//handler: async (req, reply) => {
+//     const { url } = req.query as { url: string };
+//
+//     // 🔹 тимчасова заглушка (сервіс буде пізніше)
+//     return {
+//         sourceUrl: url,
+//         title: "Demo title",
+//         author: null,
+//         publishedAt: null,
+//         content: "Demo content",
+//         images: [],
+//         links: [],
+//     };
+// },

--- a/src/modules/articalParser/routes/artical.parser.route.ts
+++ b/src/modules/articalParser/routes/artical.parser.route.ts
@@ -1,4 +1,3 @@
-// modules/parse/artical.parse.route.ts
 import type {JsonSchemaToTsProvider} from "@fastify/type-provider-json-schema-to-ts";
 import {FastifyInstance} from "fastify";
 import {parseArticleController} from "../controllers/artical.parse.controller";

--- a/src/modules/articalParser/routes/artical.parser.route.ts
+++ b/src/modules/articalParser/routes/artical.parser.route.ts
@@ -1,22 +1,24 @@
-import type {JsonSchemaToTsProvider} from "@fastify/type-provider-json-schema-to-ts";
-import {FastifyInstance} from "fastify";
-import {parseArticleController} from "../controllers/artical.parse.controller";
+import type { JsonSchemaToTsProvider } from "@fastify/type-provider-json-schema-to-ts";
+import type { FastifyInstance } from "fastify";
+import { parseArticleController } from "../controllers/artical.parse.controller";
 
 import {
-    parseArticleBody,
-    parseArticleResponse,
-} from "../schema/artical.parser.schema"
-
+	parseArticleBody,
+	parseArticleResponse,
+} from "../schema/artical.parser.schema";
 
 export async function parseRoutes(fastify: FastifyInstance) {
-    const route = fastify.withTypeProvider<JsonSchemaToTsProvider>();
-    const controller = parseArticleController(fastify);
+	const route = fastify.withTypeProvider<JsonSchemaToTsProvider>();
+	const controller = parseArticleController(fastify);
 
-
-    route.post(
-        "/parse",
-        {schema: {body: parseArticleBody, response: {200: parseArticleResponse}}},
-        controller.parseArticleController,
-    );
+	route.post(
+		"/parse",
+		{
+			schema: {
+				body: parseArticleBody,
+				response: { 200: parseArticleResponse },
+			},
+		},
+		controller.parseArticleController,
+	);
 }
-

--- a/src/modules/articalParser/routes/artical.parser.route.ts
+++ b/src/modules/articalParser/routes/artical.parser.route.ts
@@ -19,23 +19,5 @@ export async function parseRoutes(fastify: FastifyInstance) {
         {schema: {body: parseArticleBody, response: {200: parseArticleResponse}}},
         controller.parseArticleController,
     );
-
-
-
 }
 
-
-//handler: async (req, reply) => {
-//     const { url } = req.query as { url: string };
-//
-//     // 🔹 тимчасова заглушка (сервіс буде пізніше)
-//     return {
-//         sourceUrl: url,
-//         title: "Demo title",
-//         author: null,
-//         publishedAt: null,
-//         content: "Demo content",
-//         images: [],
-//         links: [],
-//     };
-// },

--- a/src/modules/articalParser/schema/artical.parser.schema.ts
+++ b/src/modules/articalParser/schema/artical.parser.schema.ts
@@ -1,0 +1,37 @@
+// modules/parse/schema.ts
+export const parseArticleResponse = {
+    type: "object",
+    properties: {
+        sourceUrl: { type: "string", format: "uri" },
+        title: { type: "string" },
+        author: { type: "string", nullable: true },
+        publishedAt: { type: "string", format: "date-time", nullable: true },
+        content: { type: "string" },
+        images: {
+            type: "array",
+            items: { type: "string", format: "uri" },
+        },
+        links: {
+            type: "array",
+            items: { type: "string", format: "uri" },
+        },
+    },
+    required: ["sourceUrl", "title", "content"],
+} as const;
+
+export const parseArticleBody = {
+    type: "object",
+    required: ["url"],
+    properties: {
+        url: { type: "string", format: "uri" },
+    },
+    additionalProperties: false,
+} as const;
+
+export const parseArticleQuery = {
+    type: "object",
+    properties: {
+        url: { type: "string", format: "uri" },
+    },
+    additionalProperties: false,
+} as const;

--- a/src/modules/articalParser/schema/artical.parser.schema.ts
+++ b/src/modules/articalParser/schema/artical.parser.schema.ts
@@ -1,4 +1,7 @@
 // Schema for the request body when parsing an article
+
+const HTTP_URL_PATTERN = "^https?:\\/\\/\\S+$" as const;
+
 export const parseArticleBody = {
 	type: "object",
 	required: ["url"],
@@ -7,7 +10,7 @@ export const parseArticleBody = {
 			type: "string",
 			minLength: 8, // Minimum URL length like "http://a"
 			maxLength: 4096, // Maximum reasonable URL length
-			pattern: "^https?:\\/\\/\\S+$", // Must start with http:// or https:// and have no spaces
+			pattern: HTTP_URL_PATTERN,
 		},
 		// Option to force parsing even for dynamic websites
 		force: {
@@ -25,7 +28,7 @@ export const parseArticleResponse = {
 		// The original URL that was parsed
 		sourceUrl: {
 			type: "string",
-			pattern: "^https?:\\/\\/\\S+$",
+			pattern: "HTTP_URL_PATTERN",
 		},
 
 		// Article title (always required)
@@ -56,7 +59,7 @@ export const parseArticleResponse = {
 			type: "array",
 			items: {
 				type: "string",
-				pattern: "^https?:\\/\\/\\S+$",
+				pattern: "HTTP_URL_PATTERN",
 			},
 			uniqueItems: true, // No duplicate URLs
 		},
@@ -66,7 +69,7 @@ export const parseArticleResponse = {
 			type: "array",
 			items: {
 				type: "string",
-				pattern: "^https?:\\/\\/\\S+$",
+				pattern: "^https?:HTTP_URL_PATTERN",
 			},
 			uniqueItems: true, // No duplicate URLs
 		},

--- a/src/modules/articalParser/schema/artical.parser.schema.ts
+++ b/src/modules/articalParser/schema/artical.parser.schema.ts
@@ -1,80 +1,80 @@
 // Schema for the request body when parsing an article
 export const parseArticleBody = {
-    type: "object",
-    required: ["url"],
-    properties: {
-        url: {
-            type: "string",
-            minLength: 8,        // Minimum URL length like "http://a"
-            maxLength: 4096,     // Maximum reasonable URL length
-            pattern: "^https?:\\/\\/\\S+$",  // Must start with http:// or https:// and have no spaces
-        },
-        // Option to force parsing even for dynamic websites
-        force: {
-            type: "boolean",
-            default: false
-        },
-    },
-    additionalProperties: false,  // Don't allow extra fields
+	type: "object",
+	required: ["url"],
+	properties: {
+		url: {
+			type: "string",
+			minLength: 8, // Minimum URL length like "http://a"
+			maxLength: 4096, // Maximum reasonable URL length
+			pattern: "^https?:\\/\\/\\S+$", // Must start with http:// or https:// and have no spaces
+		},
+		// Option to force parsing even for dynamic websites
+		force: {
+			type: "boolean",
+			default: false,
+		},
+	},
+	additionalProperties: false, // Don't allow extra fields
 };
 
 // Schema for the response when article parsing is successful
 export const parseArticleResponse = {
-    type: "object",
-    properties: {
-        // The original URL that was parsed
-        sourceUrl: {
-            type: "string",
-            pattern: "^https?:\\/\\/\\S+$"
-        },
+	type: "object",
+	properties: {
+		// The original URL that was parsed
+		sourceUrl: {
+			type: "string",
+			pattern: "^https?:\\/\\/\\S+$",
+		},
 
-        // Article title (always required)
-        title: {
-            type: "string"
-        },
+		// Article title (always required)
+		title: {
+			type: "string",
+		},
 
-        // Author name (can be null if not found)
-        author: {
-            type: ["string", "null"]
-        },
+		// Author name (can be null if not found)
+		author: {
+			type: ["string", "null"],
+		},
 
-        // Publication date (can be null if not found)
-        publishedAt: {
-            anyOf: [
-                { type: "string", format: "date-time" },  // ISO date format
-                { type: "null" }                          // or null if not found
-            ]
-        },
+		// Publication date (can be null if not found)
+		publishedAt: {
+			anyOf: [
+				{ type: "string", format: "date-time" }, // ISO date format
+				{ type: "null" }, // or null if not found
+			],
+		},
 
-        // Main article content (always required)
-        content: {
-            type: "string"
-        },
+		// Main article content (always required)
+		content: {
+			type: "string",
+		},
 
-        // Array of image URLs found in the article
-        images: {
-            type: "array",
-            items: {
-                type: "string",
-                pattern: "^https?:\\/\\/\\S+$"
-            },
-            uniqueItems: true,  // No duplicate URLs
-        },
+		// Array of image URLs found in the article
+		images: {
+			type: "array",
+			items: {
+				type: "string",
+				pattern: "^https?:\\/\\/\\S+$",
+			},
+			uniqueItems: true, // No duplicate URLs
+		},
 
-        // Array of link URLs found in the article
-        links: {
-            type: "array",
-            items: {
-                type: "string",
-                pattern: "^https?:\\/\\/\\S+$"
-            },
-            uniqueItems: true,  // No duplicate URLs
-        },
-    },
+		// Array of link URLs found in the article
+		links: {
+			type: "array",
+			items: {
+				type: "string",
+				pattern: "^https?:\\/\\/\\S+$",
+			},
+			uniqueItems: true, // No duplicate URLs
+		},
+	},
 
-    // These fields must always be present in the response
-    required: ["sourceUrl", "title", "content"],
+	// These fields must always be present in the response
+	required: ["sourceUrl", "title", "content"],
 
-    // Don't allow extra fields in the response
-    additionalProperties: false,
+	// Don't allow extra fields in the response
+	additionalProperties: false,
 };

--- a/src/modules/articalParser/schema/artical.parser.schema.ts
+++ b/src/modules/articalParser/schema/artical.parser.schema.ts
@@ -1,40 +1,80 @@
-// modules/articalParser/schema/artical.parser.schema.ts
+// Schema for the request body when parsing an article
 export const parseArticleBody = {
     type: "object",
     required: ["url"],
     properties: {
-        // Дозволяємо будь-який http/https без пробілів
         url: {
             type: "string",
-            minLength: 8,
-            maxLength: 4096,
-            pattern: "^https?:\\/\\/\\S+$",
+            minLength: 8,        // Minimum URL length like "http://a"
+            maxLength: 4096,     // Maximum reasonable URL length
+            pattern: "^https?:\\/\\/\\S+$",  // Must start with http:// or https:// and have no spaces
         },
-        // опціонально, для дев-режиму
-        force: { type: "boolean", default: false },
+        // Option to force parsing even for dynamic websites
+        force: {
+            type: "boolean",
+            default: false
+        },
     },
-    additionalProperties: false,
-} as const;
+    additionalProperties: false,  // Don't allow extra fields
+};
 
+// Schema for the response when article parsing is successful
 export const parseArticleResponse = {
     type: "object",
     properties: {
-        sourceUrl: { type: "string", pattern: "^https?:\\/\\/\\S+$" },
-        title: { type: "string" },
-        author: { type: ["string", "null"] },
-        publishedAt: { anyOf: [{ type: "string", format: "date-time" }, { type: "null" }] },
-        content: { type: "string" },
+        // The original URL that was parsed
+        sourceUrl: {
+            type: "string",
+            pattern: "^https?:\\/\\/\\S+$"
+        },
+
+        // Article title (always required)
+        title: {
+            type: "string"
+        },
+
+        // Author name (can be null if not found)
+        author: {
+            type: ["string", "null"]
+        },
+
+        // Publication date (can be null if not found)
+        publishedAt: {
+            anyOf: [
+                { type: "string", format: "date-time" },  // ISO date format
+                { type: "null" }                          // or null if not found
+            ]
+        },
+
+        // Main article content (always required)
+        content: {
+            type: "string"
+        },
+
+        // Array of image URLs found in the article
         images: {
             type: "array",
-            items: { type: "string", pattern: "^https?:\\/\\/\\S+$" },
-            uniqueItems: true,
+            items: {
+                type: "string",
+                pattern: "^https?:\\/\\/\\S+$"
+            },
+            uniqueItems: true,  // No duplicate URLs
         },
+
+        // Array of link URLs found in the article
         links: {
             type: "array",
-            items: { type: "string", pattern: "^https?:\\/\\/\\S+$" },
-            uniqueItems: true,
+            items: {
+                type: "string",
+                pattern: "^https?:\\/\\/\\S+$"
+            },
+            uniqueItems: true,  // No duplicate URLs
         },
     },
+
+    // These fields must always be present in the response
     required: ["sourceUrl", "title", "content"],
+
+    // Don't allow extra fields in the response
     additionalProperties: false,
-} as const;
+};

--- a/src/modules/articalParser/schema/artical.parser.schema.ts
+++ b/src/modules/articalParser/schema/artical.parser.schema.ts
@@ -1,37 +1,40 @@
-// modules/parse/schema.ts
-export const parseArticleResponse = {
-    type: "object",
-    properties: {
-        sourceUrl: { type: "string", format: "uri" },
-        title: { type: "string" },
-        author: { type: "string", nullable: true },
-        publishedAt: { type: "string", format: "date-time", nullable: true },
-        content: { type: "string" },
-        images: {
-            type: "array",
-            items: { type: "string", format: "uri" },
-        },
-        links: {
-            type: "array",
-            items: { type: "string", format: "uri" },
-        },
-    },
-    required: ["sourceUrl", "title", "content"],
-} as const;
-
+// modules/articalParser/schema/artical.parser.schema.ts
 export const parseArticleBody = {
     type: "object",
     required: ["url"],
     properties: {
-        url: { type: "string", format: "uri" },
+        // Дозволяємо будь-який http/https без пробілів
+        url: {
+            type: "string",
+            minLength: 8,
+            maxLength: 4096,
+            pattern: "^https?:\\/\\/\\S+$",
+        },
+        // опціонально, для дев-режиму
+        force: { type: "boolean", default: false },
     },
     additionalProperties: false,
 } as const;
 
-export const parseArticleQuery = {
+export const parseArticleResponse = {
     type: "object",
     properties: {
-        url: { type: "string", format: "uri" },
+        sourceUrl: { type: "string", pattern: "^https?:\\/\\/\\S+$" },
+        title: { type: "string" },
+        author: { type: ["string", "null"] },
+        publishedAt: { anyOf: [{ type: "string", format: "date-time" }, { type: "null" }] },
+        content: { type: "string" },
+        images: {
+            type: "array",
+            items: { type: "string", pattern: "^https?:\\/\\/\\S+$" },
+            uniqueItems: true,
+        },
+        links: {
+            type: "array",
+            items: { type: "string", pattern: "^https?:\\/\\/\\S+$" },
+            uniqueItems: true,
+        },
     },
+    required: ["sourceUrl", "title", "content"],
     additionalProperties: false,
 } as const;

--- a/src/modules/articalParser/services/artical.parse.service.ts
+++ b/src/modules/articalParser/services/artical.parse.service.ts
@@ -1,0 +1,72 @@
+// modules/articalParser/services/artical.parse.service.ts
+import * as cheerio from "cheerio";
+
+export async function parseArticle(url: string) {
+    const res = await fetch(url, {
+        headers: {
+            "user-agent": "Mozilla/5.0 (compatible; ArticleParser/1.0)",
+            "accept": "text/html,application/xhtml+xml",
+        },
+        redirect: "follow",
+    });
+    if (!res.ok) throw { code: "FETCH_FAILED", message: `Failed to fetch ${url}` };
+
+    const ctype = res.headers.get("content-type") || "";
+    if (!ctype.includes("text/html")) throw { code: "PARSING_FAILED", message: "Not an HTML page" };
+
+    const html = await res.text();
+
+    // 🔎 Дуже прості евристики SPA/SSR
+    const looksLikeSpa =
+        /id="__next"|id="root"|id="app"/i.test(html) ||               // Next/Vue/React корінь
+        /<script[^>]+type="application\/json"[^>]*>/.test(html) ||    // великі JSON-дампи
+        (html.match(/<script\b/gi)?.length || 0) > 40;                // забагато скриптів
+
+    if (looksLikeSpa) throw { code: "UNSUPPORTED_SITE" };
+
+    const $ = cheerio.load(html);
+
+    const title =
+        $("meta[property='og:title']").attr("content") ||
+        $("h1").first().text().trim() ||
+        $("title").first().text().trim() ||
+        "Untitled";
+
+    const author =
+        $("meta[name='author']").attr("content") ||
+        $('[itemprop="author"]').first().text().trim() ||
+        null;
+
+    const publishedAt =
+        $("time[datetime]").attr("datetime") ||
+        $('[itemprop="datePublished"]').attr("content") ||
+        null;
+
+    const content =
+        // спроба взяти основний текст
+        $('[role="main"], main, article')
+            .first()
+            .find("p")
+            .toArray()
+            .map((p) => $(p).text().trim())
+            .filter(Boolean)
+            .slice(0, 12)
+            .join("\n\n") || $("p").slice(0, 6).toArray().map((p) => $(p).text().trim()).filter(Boolean).join("\n\n") || "No content";
+
+    const toAbs = (href: string) => new URL(href, url).toString();
+
+    const images = $("img[src]")
+        .toArray()
+        .map((el) => $(el).attr("src")!)
+        .filter(Boolean)
+        .map(toAbs);
+
+    const links = $("a[href]")
+        .toArray()
+        .map((el) => $(el).attr("href")!)
+        .filter(Boolean)
+        .filter((h) => !h.startsWith("#") && !h.startsWith("javascript:"))
+        .map(toAbs);
+
+    return { sourceUrl: url, title, author, publishedAt, content, images, links };
+}

--- a/src/modules/articalParser/services/artical.parse.service.ts
+++ b/src/modules/articalParser/services/artical.parse.service.ts
@@ -2,166 +2,169 @@ import * as cheerio from "cheerio";
 import { isStaticEnough } from "../utils/isStaticEnough";
 
 export async function parseArticle(url: string, force = false) {
-    // Check if URL points to a file we can't parse
-    const fileExtensions = /\.(pdf|mp4|mp3|zip|rar|7z|docx?)($|\?)/i;
-    if (fileExtensions.test(url)) {
-        throw { code: "PARSING_FAILED", message: "Not an HTML page" };
-    }
+	// Check if URL points to a file we can't parse
+	const fileExtensions = /\.(pdf|mp4|mp3|zip|rar|7z|docx?)($|\?)/i;
+	if (fileExtensions.test(url)) {
+		throw { code: "PARSING_FAILED", message: "Not an HTML page" };
+	}
 
-    // Download the webpage
-    const response = await fetch(url, {
-        headers: {
-            "user-agent": "Mozilla/5.0 (compatible; ArticleParser/1.0)",
-            "accept": "text/html,application/xhtml+xml",
-        },
-        redirect: "follow",
-    });
+	// Download the webpage
+	const response = await fetch(url, {
+		headers: {
+			"user-agent": "Mozilla/5.0 (compatible; ArticleParser/1.0)",
+			accept: "text/html,application/xhtml+xml",
+		},
+		redirect: "follow",
+	});
 
-    // Check if download was successful
-    if (!response.ok) {
-        throw { code: "FETCH_FAILED", message: `Failed to fetch ${url}` };
-    }
+	// Check if download was successful
+	if (!response.ok) {
+		throw { code: "FETCH_FAILED", message: `Failed to fetch ${url}` };
+	}
 
-    // Check if we got HTML content
-    const contentType = response.headers.get("content-type") || "";
-    if (!contentType.includes("text/html")) {
-        throw { code: "PARSING_FAILED", message: `Unsupported content-type: ${contentType}` };
-    }
+	// Check if we got HTML content
+	const contentType = response.headers.get("content-type") || "";
+	if (!contentType.includes("text/html")) {
+		throw {
+			code: "PARSING_FAILED",
+			message: `Unsupported content-type: ${contentType}`,
+		};
+	}
 
-    // Get the HTML text
-    const html = await response.text();
+	// Get the HTML text
+	const html = await response.text();
 
-    // Check if website is simple enough to parse (unless forced)
-    if (!force) {
-        const staticCheck = isStaticEnough(html);
-        if (!staticCheck.ok) {
-            const errorMessage = staticCheck.reasons.join("; ");
-            throw { code: "UNSUPPORTED_SITE", message: errorMessage };
-        }
-    }
+	// Check if website is simple enough to parse (unless forced)
+	if (!force) {
+		const staticCheck = isStaticEnough(html);
+		if (!staticCheck.ok) {
+			const errorMessage = staticCheck.reasons.join("; ");
+			throw { code: "UNSUPPORTED_SITE", message: errorMessage };
+		}
+	}
 
-    // Load HTML into cheerio for parsing
-    const $ = cheerio.load(html);
+	// Load HTML into cheerio for parsing
+	const $ = cheerio.load(html);
 
-    // Find the article title
-    let title = "";
+	// Find the article title
+	let title = "";
 
-    // Try Open Graph title first
-    const ogTitle = $('meta[property="og:title"]').attr("content");
-    if (ogTitle) {
-        title = ogTitle;
-    } else {
-        // Try first H1 tag
-        const h1Title = $("h1").first().text().trim();
-        if (h1Title) {
-            title = h1Title;
-        } else {
-            // Try page title
-            const pageTitle = $("title").first().text().trim();
-            title = pageTitle || "Untitled";
-        }
-    }
+	// Try Open Graph title first
+	const ogTitle = $('meta[property="og:title"]').attr("content");
+	if (ogTitle) {
+		title = ogTitle;
+	} else {
+		// Try first H1 tag
+		const h1Title = $("h1").first().text().trim();
+		if (h1Title) {
+			title = h1Title;
+		} else {
+			// Try page title
+			const pageTitle = $("title").first().text().trim();
+			title = pageTitle || "Untitled";
+		}
+	}
 
-    // Find the author
-    let author = null;
+	// Find the author
+	let author: string | null = null;
 
-    const metaAuthor = $('meta[name="author"]').attr("content");
-    if (metaAuthor) {
-        author = metaAuthor;
-    } else {
-        const itempropAuthor = $('[itemprop="author"]').first().text().trim();
-        if (itempropAuthor) {
-            author = itempropAuthor;
-        }
-    }
+	const metaAuthor = $('meta[name="author"]').attr("content");
+	if (metaAuthor) {
+		author = metaAuthor;
+	} else {
+		const itempropAuthor = $('[itemprop="author"]').first().text().trim();
+		if (itempropAuthor) {
+			author = itempropAuthor;
+		}
+	}
 
-    // Find publication date
-    let publishedAt = null;
+	// Find publication date
+	let publishedAt: string | null = null;
 
-    const timeDateTime = $("time[datetime]").attr("datetime");
-    if (timeDateTime) {
-        publishedAt = timeDateTime;
-    } else {
-        const itempropDate = $('[itemprop="datePublished"]').attr("content");
-        if (itempropDate) {
-            publishedAt = itempropDate;
-        }
-    }
+	const timeDateTime = $("time[datetime]").attr("datetime");
+	if (timeDateTime) {
+		publishedAt = timeDateTime;
+	} else {
+		const itempropDate = $('[itemprop="datePublished"]').attr("content");
+		if (itempropDate) {
+			publishedAt = itempropDate;
+		}
+	}
 
-    // Function to make relative URLs absolute
-    function makeAbsoluteUrl(href: string): string {
-        return new URL(href, url).toString();
-    }
+	// Function to make relative URLs absolute
+	function makeAbsoluteUrl(href: string): string {
+		return new URL(href, url).toString();
+	}
 
-    // Find the main content
-    let content = "No content";
+	// Find the main content
+	let content = "No content";
 
-    // First try to find content in main sections
-    const mainSections = $('[role="main"], main, article').first();
-    if (mainSections.length > 0) {
-        const paragraphs: string[] = [];
-        mainSections.find("p").each((index, element) => {
-            const text = $(element).text().trim();
-            if (text && paragraphs.length < 12) {
-                paragraphs.push(text);
-            }
-        });
+	// First try to find content in main sections
+	const mainSections = $('[role="main"], main, article').first();
+	if (mainSections.length > 0) {
+		const paragraphs: string[] = [];
+		mainSections.find("p").each((_index, element) => {
+			const text = $(element).text().trim();
+			if (text && paragraphs.length < 12) {
+				paragraphs.push(text);
+			}
+		});
 
-        if (paragraphs.length > 0) {
-            content = paragraphs.join("\n\n");
-        }
-    }
+		if (paragraphs.length > 0) {
+			content = paragraphs.join("\n\n");
+		}
+	}
 
-    // If no main content found, try all paragraphs
-    if (content === "No content") {
-        const allParagraphs: string[] = [];
-        $("p").each((index, element) => {
-            const text = $(element).text().trim();
-            if (text && allParagraphs.length < 6) {
-                allParagraphs.push(text);
-            }
-        });
+	// If no main content found, try all paragraphs
+	if (content === "No content") {
+		const allParagraphs: string[] = [];
+		$("p").each((_index, element) => {
+			const text = $(element).text().trim();
+			if (text && allParagraphs.length < 6) {
+				allParagraphs.push(text);
+			}
+		});
 
-        if (allParagraphs.length > 0) {
-            content = allParagraphs.join("\n\n");
-        }
-    }
+		if (allParagraphs.length > 0) {
+			content = allParagraphs.join("\n\n");
+		}
+	}
 
-    // Find all images
-    const imageUrls: string[] = [];
-    $("img[src]").each((index, element) => {
-        const src = $(element).attr("src");
-        if (src) {
-            const absoluteUrl = makeAbsoluteUrl(src);
-            if (!imageUrls.includes(absoluteUrl)) {
-                imageUrls.push(absoluteUrl);
-            }
-        }
-    });
+	// Find all images
+	const imageUrls: string[] = [];
+	$("img[src]").each((_index, element) => {
+		const src = $(element).attr("src");
+		if (src) {
+			const absoluteUrl = makeAbsoluteUrl(src);
+			if (!imageUrls.includes(absoluteUrl)) {
+				imageUrls.push(absoluteUrl);
+			}
+		}
+	});
 
-    // Find all links
-    const linkUrls: string[] = [];
-    $("a[href]").each((index, element) => {
-        const href = $(element).attr("href");
-        if (href) {
-            // Skip internal page links and javascript links
-            if (!href.startsWith("#") && !href.startsWith("javascript:")) {
-                const absoluteUrl = makeAbsoluteUrl(href);
-                if (!linkUrls.includes(absoluteUrl)) {
-                    linkUrls.push(absoluteUrl);
-                }
-            }
-        }
-    });
+	// Find all links
+	const linkUrls: string[] = [];
+	$("a[href]").each((_index, element) => {
+		const href = $(element).attr("href");
+		if (href) {
+			// Skip internal page links and javascript links
+			if (!href.startsWith("#") && !href.startsWith("javascript:")) {
+				const absoluteUrl = makeAbsoluteUrl(href);
+				if (!linkUrls.includes(absoluteUrl)) {
+					linkUrls.push(absoluteUrl);
+				}
+			}
+		}
+	});
 
-    // Return the parsed data
-    return {
-        sourceUrl: url,
-        title: title,
-        author: author,
-        publishedAt: publishedAt,
-        content: content,
-        images: imageUrls,
-        links: linkUrls
-    };
+	// Return the parsed data
+	return {
+		sourceUrl: url,
+		title,
+		author,
+		publishedAt,
+		content,
+		images: imageUrls,
+		links: linkUrls,
+	};
 }

--- a/src/modules/articalParser/services/artical.parse.service.ts
+++ b/src/modules/articalParser/services/artical.parse.service.ts
@@ -1,69 +1,167 @@
-// services/artical.parse.service.ts
 import * as cheerio from "cheerio";
-import { isStaticEnough } from "../utils/isStaticEnough"; // як раніше
+import { isStaticEnough } from "../utils/isStaticEnough";
 
 export async function parseArticle(url: string, force = false) {
-    if (/\.(pdf|mp4|mp3|zip|rar|7z|docx?)($|\?)/i.test(url)) {
+    // Check if URL points to a file we can't parse
+    const fileExtensions = /\.(pdf|mp4|mp3|zip|rar|7z|docx?)($|\?)/i;
+    if (fileExtensions.test(url)) {
         throw { code: "PARSING_FAILED", message: "Not an HTML page" };
     }
 
-    const res = await fetch(url, {
+    // Download the webpage
+    const response = await fetch(url, {
         headers: {
             "user-agent": "Mozilla/5.0 (compatible; ArticleParser/1.0)",
             "accept": "text/html,application/xhtml+xml",
         },
         redirect: "follow",
     });
-    if (!res.ok) throw { code: "FETCH_FAILED", message: `Failed to fetch ${url}` };
 
-    const ctype = res.headers.get("content-type") || "";
-    if (!ctype.includes("text/html")) {
-        throw { code: "PARSING_FAILED", message: `Unsupported content-type: ${ctype}` };
+    // Check if download was successful
+    if (!response.ok) {
+        throw { code: "FETCH_FAILED", message: `Failed to fetch ${url}` };
     }
 
-    const html = await res.text();
+    // Check if we got HTML content
+    const contentType = response.headers.get("content-type") || "";
+    if (!contentType.includes("text/html")) {
+        throw { code: "PARSING_FAILED", message: `Unsupported content-type: ${contentType}` };
+    }
+
+    // Get the HTML text
+    const html = await response.text();
+
+    // Check if website is simple enough to parse (unless forced)
     if (!force) {
-        const stat = isStaticEnough(html);
-        if (!stat.ok) throw { code: "UNSUPPORTED_SITE", message: stat.reasons.join("; ") };
+        const staticCheck = isStaticEnough(html);
+        if (!staticCheck.ok) {
+            const errorMessage = staticCheck.reasons.join("; ");
+            throw { code: "UNSUPPORTED_SITE", message: errorMessage };
+        }
     }
 
+    // Load HTML into cheerio for parsing
     const $ = cheerio.load(html);
 
-    const title =
-        $('meta[property="og:title"]').attr("content") ||
-        $("h1").first().text().trim() ||
-        $("title").first().text().trim() ||
-        "Untitled";
+    // Find the article title
+    let title = "";
 
-    const author =
-        $('meta[name="author"]').attr("content") ||
-        $('[itemprop="author"]').first().text().trim() ||
-        null;
+    // Try Open Graph title first
+    const ogTitle = $('meta[property="og:title"]').attr("content");
+    if (ogTitle) {
+        title = ogTitle;
+    } else {
+        // Try first H1 tag
+        const h1Title = $("h1").first().text().trim();
+        if (h1Title) {
+            title = h1Title;
+        } else {
+            // Try page title
+            const pageTitle = $("title").first().text().trim();
+            title = pageTitle || "Untitled";
+        }
+    }
 
-    const publishedAt =
-        $("time[datetime]").attr("datetime") ||
-        $('[itemprop="datePublished"]').attr("content") ||
-        null;
+    // Find the author
+    let author = null;
 
-    const toAbs = (href: string) => new URL(href, url).toString();
+    const metaAuthor = $('meta[name="author"]').attr("content");
+    if (metaAuthor) {
+        author = metaAuthor;
+    } else {
+        const itempropAuthor = $('[itemprop="author"]').first().text().trim();
+        if (itempropAuthor) {
+            author = itempropAuthor;
+        }
+    }
 
-    const content =
-        ($('[role="main"], main, article').first().find("p").toArray()
-            .map(p => $(p).text().trim()).filter(Boolean).slice(0, 12).join("\n\n"))
-        || ($("p").slice(0, 6).toArray()
-            .map(p => $(p).text().trim()).filter(Boolean).join("\n\n"))
-        || "No content";
+    // Find publication date
+    let publishedAt = null;
 
-    const images = Array.from(new Set(
-        $("img[src]").toArray()
-            .map(el => $(el).attr("src")!).filter(Boolean).map(toAbs)
-    ));
-    const links = Array.from(new Set(
-        $("a[href]").toArray()
-            .map(el => $(el).attr("href")!).filter(Boolean)
-            .filter(h => !h.startsWith("#") && !h.startsWith("javascript:"))
-            .map(toAbs)
-    ));
+    const timeDateTime = $("time[datetime]").attr("datetime");
+    if (timeDateTime) {
+        publishedAt = timeDateTime;
+    } else {
+        const itempropDate = $('[itemprop="datePublished"]').attr("content");
+        if (itempropDate) {
+            publishedAt = itempropDate;
+        }
+    }
 
-    return { sourceUrl: url, title, author, publishedAt, content, images, links };
+    // Function to make relative URLs absolute
+    function makeAbsoluteUrl(href: string): string {
+        return new URL(href, url).toString();
+    }
+
+    // Find the main content
+    let content = "No content";
+
+    // First try to find content in main sections
+    const mainSections = $('[role="main"], main, article').first();
+    if (mainSections.length > 0) {
+        const paragraphs: string[] = [];
+        mainSections.find("p").each((index, element) => {
+            const text = $(element).text().trim();
+            if (text && paragraphs.length < 12) {
+                paragraphs.push(text);
+            }
+        });
+
+        if (paragraphs.length > 0) {
+            content = paragraphs.join("\n\n");
+        }
+    }
+
+    // If no main content found, try all paragraphs
+    if (content === "No content") {
+        const allParagraphs: string[] = [];
+        $("p").each((index, element) => {
+            const text = $(element).text().trim();
+            if (text && allParagraphs.length < 6) {
+                allParagraphs.push(text);
+            }
+        });
+
+        if (allParagraphs.length > 0) {
+            content = allParagraphs.join("\n\n");
+        }
+    }
+
+    // Find all images
+    const imageUrls: string[] = [];
+    $("img[src]").each((index, element) => {
+        const src = $(element).attr("src");
+        if (src) {
+            const absoluteUrl = makeAbsoluteUrl(src);
+            if (!imageUrls.includes(absoluteUrl)) {
+                imageUrls.push(absoluteUrl);
+            }
+        }
+    });
+
+    // Find all links
+    const linkUrls: string[] = [];
+    $("a[href]").each((index, element) => {
+        const href = $(element).attr("href");
+        if (href) {
+            // Skip internal page links and javascript links
+            if (!href.startsWith("#") && !href.startsWith("javascript:")) {
+                const absoluteUrl = makeAbsoluteUrl(href);
+                if (!linkUrls.includes(absoluteUrl)) {
+                    linkUrls.push(absoluteUrl);
+                }
+            }
+        }
+    });
+
+    // Return the parsed data
+    return {
+        sourceUrl: url,
+        title: title,
+        author: author,
+        publishedAt: publishedAt,
+        content: content,
+        images: imageUrls,
+        links: linkUrls
+    };
 }

--- a/src/modules/articalParser/utils/isStaticEnough.ts
+++ b/src/modules/articalParser/utils/isStaticEnough.ts
@@ -1,0 +1,49 @@
+// modules/articalParser/utils/isStaticEnough.ts
+export function isStaticEnough(html: string) {
+    const reasons: string[] = [];
+    const lower = html.toLowerCase();
+
+    // 1) Явні маркери SPA/SSR
+    const spaMarkers = [
+        'id="__next"', 'id="root"', 'id="app"', 'data-reactroot',
+        'window.__nuxt__', '__NUXT__', 'astro-island', 'sveltekit',
+        'webpackchunk', '/@vite/client', 'vite/client',
+    ];
+    if (spaMarkers.some(m => lower.includes(m.toLowerCase()))) {
+        reasons.push("SPA/SSR marker detected");
+    }
+
+    // 2) Багато скриптів або “важкі” скрипти
+    const scriptTags = lower.match(/<script\b[^>]*>/g) || [];
+    const scriptCount = scriptTags.length;
+    if (scriptCount > 40) reasons.push(`Too many scripts: ${scriptCount}`);
+
+    const totalBytes = html.length;
+    const scriptBlocks = Array.from(html.matchAll(/<script\b[^>]*>([\s\S]*?)<\/script>/gi));
+    const scriptBytes = scriptBlocks.reduce((acc, m) => acc + (m[1]?.length ?? 0), 0);
+    const scriptShare = totalBytes ? scriptBytes / totalBytes : 0;
+    if (scriptShare > 0.35) reasons.push(`Script share too high: ${(scriptShare*100).toFixed(0)}%`);
+
+    // 3) Важкі JSON-дампи
+    const bigJsonDump = Array.from(html.matchAll(/<script[^>]+type=["']application\/json["'][^>]*>([\s\S]*?)<\/script>/gi))
+        .some(m => (m[1]?.length ?? 0) > 50_000);
+    if (bigJsonDump) reasons.push("Big JSON dump in script tags");
+
+    // 4) Перевірка на наявність реального тексту
+    const mainTextChars =
+        (lower.match(/<(main|article)\b[\s\S]*?<\/\1>/)?.[0] || html)
+            .replace(/<style[\s\S]*?<\/style>/gi, "")
+            .replace(/<script[\s\S]*?<\/script>/gi, "")
+            .replace(/<[^>]+>/g, "")
+            .replace(/\s+/g, " ")
+            .trim().length;
+
+    if (mainTextChars < 600) reasons.push(`Too little main text: ${mainTextChars} chars`);
+
+    // 5) Повідомлення про вимкнений JS
+    if (lower.includes("please enable javascript")) reasons.push("Message: please enable JavaScript");
+
+    // Проста оцінка: якщо є хоч одна “погана” причина — вважаємо не статичним
+    const ok = reasons.length === 0;
+    return { ok, reasons, score: ok ? 1 : 0 };
+}


### PR DESCRIPTION

Hello @Gunnar97 

This is part of task number 3.

feat(parse): add /api/parse endpoint for article parsing

*implemented POST /api/parse endpoint
*accepts url (+ optional force), normalizes and validates input
*rejects SPA/SSR pages (isStaticEnough)
*parses static HTML using Cheerio
*returns JSON: sourceUrl, title, author, publishedAt, content, images[], links[]
*maps errors to proper HTTP status codes
*added JSON schemas for request body and response
*tested in Postman with NASA article example

next: integrate client-server requests; possibly add limits 
for the number of objects returned in feedParser and articleParser modules
